### PR TITLE
Mharrison info show to user

### DIFF
--- a/information-service/src/main/java/com/lms/informationservice/InformationServiceApplication.java
+++ b/information-service/src/main/java/com/lms/informationservice/InformationServiceApplication.java
@@ -11,9 +11,13 @@ import io.github.cdimascio.dotenv.Dotenv;
 public class InformationServiceApplication {
 
     public static void main(String[] args) {
-        Dotenv dotenv = Dotenv.load();
+        Dotenv dotenv = Dotenv.configure().directory("../").load();
+        System.setProperty("DB_TEAMS_URL", dotenv.get("DB_TEAMS_URL"));
         System.setProperty("DB_USERNAME", dotenv.get("DB_USERNAME"));
         System.setProperty("DB_PASSWORD", dotenv.get("DB_PASSWORD"));
+        String dbUrl = System.getProperty("DB_TEAMS_URL");
+        System.out.println(dbUrl);
+
         SpringApplication.run(InformationServiceApplication.class, args);
     }
 }

--- a/information-service/src/main/java/com/lms/informationservice/controller/InformationController.java
+++ b/information-service/src/main/java/com/lms/informationservice/controller/InformationController.java
@@ -45,7 +45,7 @@ public class InformationController {
      *
      * Retrieve teams from the API, storing the retrieved teams in the database, and returning a list of all teams.
      *
-     * @return ResponseEntity<List<Team>> Response entity containing a list of all teams in the database.
+     * @return ResponseEntity<List<Team>> Response entity containing a list of all teams in the API.
      */
     @GetMapping("/teams/fetch")
     public ResponseEntity<List<Team>> fetchTeams() {
@@ -56,6 +56,20 @@ public class InformationController {
         return ResponseEntity.ok(teams);
     }
 
+    /**
+     * Endpoint to get all team data from the database and provide it to the user
+     * It differs from the fetch endpoint in that it does not interact with the API, only the database.
+     * This'll be called whenever a user wants to see information about teams in the league etc
+     * while the fetch method will be called to update the teams ranking at the start of and during the course of a league
+     *
+     *
+     * @return ResponseEntity<List<Teams>> Response entity containing a list of all teams in the database.
+     */
+    @GetMapping("/teams/get-teams")
+    public ResponseEntity<List<Team>> getTeams(){
+        List<Team> teams = db.getTeamsFromDB();
+        return ResponseEntity.ok(teams);
+    }
     /**
      * Endpoint to fetch and store all match fixtures from the external API.
      *

--- a/information-service/src/main/java/com/lms/informationservice/database/InformationDatabaseController.java
+++ b/information-service/src/main/java/com/lms/informationservice/database/InformationDatabaseController.java
@@ -17,7 +17,6 @@ import java.util.logging.Logger;
  *
  * @author Mark Harrison
  */
-@Entity
 public class InformationDatabaseController{
 
     private static final Logger log;
@@ -38,21 +37,12 @@ public class InformationDatabaseController{
      */
     private final static String dbUsername = System.getProperty("DB_USERNAME");
     private final static String dbPassword = System.getProperty("DB_PASSWORD");
+    private final static String dbUrl = System.getProperty("DB_TEAMS_URL");
+
     public static boolean connectToDB(){
-            log.info("Loading application properties");
-
-        Properties properties = new Properties();
-        try {
-            properties.load(InformationDatabaseController.class.getClassLoader().getResourceAsStream("database.properties"));
-        } catch (IOException e){
-            log.severe("Error loading properties");
-            return false;
-        }
-
-
         log.info("Connecting to the database");
         try{
-            connection = DriverManager.getConnection(properties.getProperty("url"), dbUsername ,dbPassword);
+            connection = DriverManager.getConnection(dbUrl, dbUsername ,dbPassword);
             log.info("Database connection test: " + connection.getCatalog());
             return true;
         } catch (SQLException e){

--- a/information-service/src/main/java/com/lms/informationservice/database/InformationDatabaseController.java
+++ b/information-service/src/main/java/com/lms/informationservice/database/InformationDatabaseController.java
@@ -29,7 +29,7 @@ public class InformationDatabaseController{
 
     /**
      * Connects to the database
-     * Pulls data from the database.properties file.
+     * Pulls data from the system properties
      * driver manager handles connection
      *
      * @return          The boolean value of if the connection succeeded
@@ -77,6 +77,38 @@ public class InformationDatabaseController{
         }
 
     }
+    /**
+     * Fetches all teams in the database
+     * @return boolean representing if the operation was successful
+     */
+    public static List<Team> getTeamsFromDB(){
+        List<Team> resultsList = new ArrayList<>();
+
+        if (connection == null) {
+            log.severe("Database connection is null.");
+            return resultsList;
+        }
+
+
+        String sql = "SELECT * FROM teams";
+        try (PreparedStatement statement = connection.prepareStatement(sql)){
+            ResultSet results = statement.executeQuery();
+
+            while(results.next()){
+                Team t = new Team();
+                t.setTeamID(results.getInt("team_id"));
+                t.setTeamName(results.getString("team_name"));
+                t.setTla(results.getString("abbreviation"));
+                        resultsList.add(t);
+            }
+            return resultsList;
+        }catch (SQLException e){
+            log.severe("Error fetching teams " + e.getMessage());
+            return resultsList;
+        }
+
+    }
+
 
 
 }

--- a/information-service/src/main/resources/application.properties
+++ b/information-service/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 # MySQL Database Connection Configuration
-spring.datasource.url=jdbc:mysql://database-users.mysql.database.azure.com:3306/teams?useSSL=true
+spring.datasource.url=${DB_TEAMS_URL}
 spring.datasource.username=${DB_USERNAME}
 spring.datasource.password=${DB_PASSWORD}
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver

--- a/information-service/src/main/resources/database.properties
+++ b/information-service/src/main/resources/database.properties
@@ -1,1 +1,0 @@
-url=jdbc:mysql://database-users.mysql.database.azure.com:3306/teams?useSSL=true

--- a/notification-service/pom.xml
+++ b/notification-service/pom.xml
@@ -41,6 +41,11 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>mysql</groupId>
+			<artifactId>mysql-connector-java</artifactId>
+			<version>8.0.33</version>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-amqp</artifactId>
 		</dependency>

--- a/notification-service/src/main/java/com/lms/notificationservice/NotificationServiceApplication.java
+++ b/notification-service/src/main/java/com/lms/notificationservice/NotificationServiceApplication.java
@@ -8,6 +8,7 @@ import org.springframework.context.event.EventListener;
 import com.lms.notificationservice.model.Notification;
 import com.lms.notificationservice.service.NotificationService;
 import io.github.cdimascio.dotenv.Dotenv;
+import com.lms.notificationservice.database.NotificationDatabaseController;
 
 @SpringBootApplication
 public class NotificationServiceApplication {
@@ -15,11 +16,18 @@ public class NotificationServiceApplication {
 	private NotificationService notificationService;
 	private Notification notification = new Notification("lastmanstanding.notifier@gmail.com", "Hello", "Test Subject");
 
+
 	public static void main(String[] args) {
+		NotificationDatabaseController db = new NotificationDatabaseController();
 		Dotenv dotenv = Dotenv.load();
 		System.setProperty("NOTIFICATION_SERVICE_APP_PASSWORD", dotenv.get("NOTIFICATION_SERVICE_APP_PASSWORD"));
+		System.setProperty("DB_USERNAME", dotenv.get("DB_USERNAME"));
+		System.setProperty("DB_PASSWORD", dotenv.get("DB_PASSWORD"));
+
+
 		SpringApplication.run(NotificationServiceApplication.class, args);
 	}
+
 	@EventListener(ApplicationReadyEvent.class)
 	public void triggerMail() {
 		notificationService.sendNotification(notification);

--- a/notification-service/src/main/java/com/lms/notificationservice/NotificationServiceApplication.java
+++ b/notification-service/src/main/java/com/lms/notificationservice/NotificationServiceApplication.java
@@ -24,6 +24,7 @@ public class NotificationServiceApplication {
     public static void main(String[] args) {
         Dotenv dotenv = Dotenv.configure().directory("../").load();
         System.setProperty("NOTIFICATION_SERVICE_APP_PASSWORD", dotenv.get("NOTIFICATION_SERVICE_APP_PASSWORD"));
+        System.setProperty("DB_GAMES_URL", dotenv.get("DB_GAMES_URL"));
         System.setProperty("DB_USERNAME", dotenv.get("DB_USERNAME"));
         System.setProperty("DB_PASSWORD", dotenv.get("DB_PASSWORD"));
 

--- a/notification-service/src/main/java/com/lms/notificationservice/database/NotificationDatabaseController.java
+++ b/notification-service/src/main/java/com/lms/notificationservice/database/NotificationDatabaseController.java
@@ -12,7 +12,12 @@ import java.util.logging.Logger;
 
 
 public class NotificationDatabaseController{
-
+    /**
+     * Class responsible for controlling database operations.
+     * This class connects to the database and has mathods for modifying/adding to the games database specifically
+     *
+     * @author Mark Harrison
+     */
     private static final Logger log;
     private static Connection connection;
 
@@ -24,7 +29,7 @@ public class NotificationDatabaseController{
 
     /**
      * Connects to the database
-     * Pulls data from the database.properties file.
+     * Pulls data from the system properties
      * driver manager handles connection
      *
      * @return          The boolean value of if the connection succeeded

--- a/notification-service/src/main/java/com/lms/notificationservice/database/NotificationDatabaseController.java
+++ b/notification-service/src/main/java/com/lms/notificationservice/database/NotificationDatabaseController.java
@@ -2,7 +2,7 @@ package com.lms.notificationservice.database;
 
 import com.lms.notificationservice.model.Notification;
 import com.mysql.cj.jdbc.AbandonedConnectionCleanupThread;
-
+import jakarta.persistence.*;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.sql.*;
@@ -10,6 +10,7 @@ import java.time.LocalDateTime;
 import java.util.*;
 import java.util.logging.Logger;
 
+@Entity
 public class NotificationDatabaseController{
 
     private static final Logger log;

--- a/notification-service/src/main/java/com/lms/notificationservice/database/NotificationDatabaseController.java
+++ b/notification-service/src/main/java/com/lms/notificationservice/database/NotificationDatabaseController.java
@@ -33,20 +33,13 @@ public class NotificationDatabaseController{
     public static boolean connectToDB(){
 
 
-
-        log.info("Loading application properties");
-        Properties properties = new Properties();
-        try {
-            properties.load(NotificationDatabaseController.class.getClassLoader().getResourceAsStream("database.properties"));
-        } catch (IOException e){
-            log.severe("Error loading properties");
-            return false;
-        }
         log.info("Connecting to the database");
         try{
             String dbUsername = System.getProperty("DB_USERNAME");
             String dbPassword = System.getProperty("DB_PASSWORD");
-            connection = DriverManager.getConnection(properties.getProperty("url"), dbUsername, dbPassword);
+            String dbUrl = System.getProperty("DB_GAMES_URL");
+
+            connection = DriverManager.getConnection(dbUrl, dbUsername, dbPassword);
             log.info("Database connection test: " + connection.getCatalog());
             return true;
         } catch (SQLException e){

--- a/notification-service/src/main/java/com/lms/notificationservice/database/NotificationDatabaseController.java
+++ b/notification-service/src/main/java/com/lms/notificationservice/database/NotificationDatabaseController.java
@@ -1,0 +1,102 @@
+package com.lms.notificationservice.database;
+
+import com.lms.notificationservice.model.Notification;
+import com.mysql.cj.jdbc.AbandonedConnectionCleanupThread;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.sql.*;
+import java.time.LocalDateTime;
+import java.util.*;
+import java.util.logging.Logger;
+
+public class NotificationDatabaseController{
+
+    private static final Logger log;
+    private static Connection connection;
+
+    static {
+        System.setProperty("java.util.logging.SimpleFormatter.format", "[%4$-7s] %5$s %n");
+        log =Logger.getLogger(NotificationDatabaseController.class.getName());
+    }
+
+
+    /**
+     * Connects to the database
+     * Pulls data from the database.properties file.
+     * driver manager handles connection
+     *
+     * @return          The boolean value of if the connection succeeded
+     *
+     */
+    public static boolean connectToDB(){
+
+
+
+        log.info("Loading application properties");
+        Properties properties = new Properties();
+        try {
+            properties.load(NotificationDatabaseController.class.getClassLoader().getResourceAsStream("database.properties"));
+        } catch (IOException e){
+            log.severe("Error loading properties");
+            return false;
+        }
+        log.info("Connecting to the database");
+        try{
+            String dbUsername = System.getProperty("DB_USERNAME");
+            String dbPassword = System.getProperty("DB_PASSWORD");
+            connection = DriverManager.getConnection(properties.getProperty("url"), dbUsername, dbPassword);
+            log.info("Database connection test: " + connection.getCatalog());
+            return true;
+        } catch (SQLException e){
+            log.severe("DB Connection failed");
+            return false;
+        }
+    }
+    /**
+     * PreparedStatement.executeUpdate() handles adding rows to the database emails
+     *
+     * @return          returns the boolean status of the function
+     */
+    public static boolean addEmailToDB(Notification email){
+
+        //Sample data for now, replace with actual data pulled from user input later
+        String sql = "INSERT INTO emails ( recipient, subject, time_sent) VALUES ( ?, ?, ?)";
+        try (PreparedStatement statement = connection.prepareStatement(sql)){
+
+            statement.setString(1, email.getRecipient());
+            statement.setString(2, email.getSubject());
+            statement.setTimestamp(3, Timestamp.valueOf(LocalDateTime.now()));
+
+
+            int execute = statement.executeUpdate();
+            return true;
+        }catch (SQLException e){
+            log.severe("Error inserting email " + e.getMessage());
+            return false;
+        }
+
+    }
+
+    /**
+     * Disconnects from database
+     *
+     * @return  boolean value of the operation
+     */
+    public static boolean disconnectFromDB() {
+        if(connection != null) {
+            try {
+                connection.close();
+                log.info("DB Connection Closed");
+                return true;
+            } catch (SQLException e) {
+                log.severe("Failed to disconnect from DB");
+                return false;
+            }
+        }else{
+            log.info("No database connection");
+            return false;
+
+        }
+    }
+}

--- a/notification-service/src/main/java/com/lms/notificationservice/service/NotificationService.java
+++ b/notification-service/src/main/java/com/lms/notificationservice/service/NotificationService.java
@@ -5,14 +5,17 @@ import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
 import com.lms.notificationservice.model.Notification;
-
+import com.lms.notificationservice.database.NotificationDatabaseController;
 @Service
 public class NotificationService {
     @Autowired
     private JavaMailSender mailSender;
 
     public void sendNotification(Notification notification) {
+        NotificationDatabaseController db = new NotificationDatabaseController();
         SimpleMailMessage message = new SimpleMailMessage();
+        db.connectToDB();
+        db.addEmailToDB(notification);
         message.setFrom("lastmanstanding.notifier@gmail.com");
         message.setTo(notification.getRecipient());
         message.setSubject(notification.getSubject());

--- a/notification-service/src/main/resources/application.properties
+++ b/notification-service/src/main/resources/application.properties
@@ -7,6 +7,6 @@ spring.mail.password=${NOTIFICATION_SERVICE_APP_PASSWORD}
 spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.starttls.enable=true
 #database related
-spring.datasource.url=jdbc:mysql://database-users.mysql.database.azure.com:3306/games?useSSL=true
+spring.datasource.url=${DB_GAMES_URL}
 spring.datasource.username=${DB_USERNAME}
 spring.datasource.password=${DB_PASSWORD}

--- a/notification-service/src/main/resources/application.properties
+++ b/notification-service/src/main/resources/application.properties
@@ -6,3 +6,7 @@ spring.mail.username=lastmanstanding.notifier@gmail.com
 spring.mail.password=${NOTIFICATION_SERVICE_APP_PASSWORD}
 spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.starttls.enable=true
+#database related
+spring.datasource.url=jdbc:mysql://database-users.mysql.database.azure.com:3306/games?useSSL=true
+spring.datasource.username=${DB_USERNAME}
+spring.datasource.password=${DB_PASSWORD}

--- a/notification-service/src/main/resources/database.properties
+++ b/notification-service/src/main/resources/database.properties
@@ -1,3 +1,0 @@
-url=jdbc:mysql://database-users.mysql.database.azure.com:3306/games?useSSL=true
-user=BigDataAdmin
-password=CS4337Group1

--- a/notification-service/src/main/resources/database.properties
+++ b/notification-service/src/main/resources/database.properties
@@ -1,0 +1,3 @@
+url=jdbc:mysql://database-users.mysql.database.azure.com:3306/games?useSSL=true
+user=BigDataAdmin
+password=CS4337Group1

--- a/user-service/src/main/java/com/lms/userservice/UserServiceApplication.java
+++ b/user-service/src/main/java/com/lms/userservice/UserServiceApplication.java
@@ -8,10 +8,13 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 public class UserServiceApplication {
 
     public static void main(String[] args) {
-        Dotenv dotenv = Dotenv.load();
+        Dotenv dotenv = Dotenv.configure().directory("../").load();
         System.setProperty("DB_USERNAME", dotenv.get("DB_USERNAME"));
         System.setProperty("DB_PASSWORD", dotenv.get("DB_PASSWORD"));
+        System.setProperty("DB_URL", dotenv.get("DB_URL"));
         System.setProperty("FIREBASE_API_KEY", dotenv.get("FIREBASE_API_KEY"));
+
+
         SpringApplication.run(UserServiceApplication.class, args);
     }
 }

--- a/user-service/src/main/java/com/lms/userservice/UserServiceApplication.java
+++ b/user-service/src/main/java/com/lms/userservice/UserServiceApplication.java
@@ -11,7 +11,7 @@ public class UserServiceApplication {
         Dotenv dotenv = Dotenv.configure().directory("../").load();
         System.setProperty("DB_USERNAME", dotenv.get("DB_USERNAME"));
         System.setProperty("DB_PASSWORD", dotenv.get("DB_PASSWORD"));
-        System.setProperty("DB_URL", dotenv.get("DB_URL"));
+        System.setProperty("DB_USERS_URL", dotenv.get("DB_USERS_URL"));
         System.setProperty("FIREBASE_API_KEY", dotenv.get("FIREBASE_API_KEY"));
 
 

--- a/user-service/src/main/java/com/lms/userservice/database/UserDatabaseConnector.java
+++ b/user-service/src/main/java/com/lms/userservice/database/UserDatabaseConnector.java
@@ -37,7 +37,7 @@ public class UserDatabaseConnector{
         try{
             String dbUsername = System.getProperty("DB_USERNAME");
             String dbPassword = System.getProperty("DB_PASSWORD");
-            String dbUrl = System.getProperty("DB_URL");
+            String dbUrl = System.getProperty("DB_USERS_URL");
             System.out.println(dbUrl);
             connection = DriverManager.getConnection(dbUrl, dbUsername, dbPassword);
             log.info("Database connection test: " + connection.getCatalog());

--- a/user-service/src/main/java/com/lms/userservice/database/UserDatabaseConnector.java
+++ b/user-service/src/main/java/com/lms/userservice/database/UserDatabaseConnector.java
@@ -22,7 +22,7 @@ public class UserDatabaseConnector{
 
     /**
      * Connects to the database
-     * Pulls data from the database.properties file.
+     * Pulls data from the system properties
      * driver manager handles connection
      *
      * @return          The boolean value of if the connection succeeded

--- a/user-service/src/main/java/com/lms/userservice/database/UserDatabaseConnector.java
+++ b/user-service/src/main/java/com/lms/userservice/database/UserDatabaseConnector.java
@@ -30,19 +30,16 @@ public class UserDatabaseConnector{
      */
     public static boolean connectToDB(){
 
-        log.info("Loading application properties");
-        Properties properties = new Properties();
-        try {
-            properties.load(UserDatabaseConnector.class.getClassLoader().getResourceAsStream("database.properties"));
-        } catch (IOException e){
-            log.severe("Error loading properties");
-            return false;
-        }
+
 
 
         log.info("Connecting to the database");
         try{
-            connection = DriverManager.getConnection(properties.getProperty("url"), properties.getProperty("user"), properties.getProperty("password"));
+            String dbUsername = System.getProperty("DB_USERNAME");
+            String dbPassword = System.getProperty("DB_PASSWORD");
+            String dbUrl = System.getProperty("DB_URL");
+            System.out.println(dbUrl);
+            connection = DriverManager.getConnection(dbUrl, dbUsername, dbPassword);
             log.info("Database connection test: " + connection.getCatalog());
             return true;
         } catch (SQLException e){

--- a/user-service/src/main/resources/application.properties
+++ b/user-service/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 # MySQL Database Connection Configuration
-spring.datasource.url=${DB_URL}
+spring.datasource.url=${DB_USERS_URL}
 spring.datasource.username=${DB_USERNAME}
 spring.datasource.password=${DB_PASSWORD}
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver

--- a/user-service/src/main/resources/application.properties
+++ b/user-service/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 # MySQL Database Connection Configuration
-spring.datasource.url=jdbc:mysql://database-users.mysql.database.azure.com:3306/users?useSSL=true
+spring.datasource.url=${DB_URL}
 spring.datasource.username=${DB_USERNAME}
 spring.datasource.password=${DB_PASSWORD}
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver

--- a/user-service/src/main/resources/database.properties
+++ b/user-service/src/main/resources/database.properties
@@ -1,2 +1,0 @@
-url=jdbc:mysql://database-users.mysql.database.azure.com:3306/users?useSSL=true
-


### PR DESCRIPTION
there already exists a fetch teams endpoint in information-services, which fetches data from the league API and updates the database if necessary
however, we don't want to call this api every time a user wants to see a list of teams in the league
so this endpoint pulls the team data directly from the database where it is stored, without calling the api. 