### PR TITLE
changed how dotenv files are read, all services have own .env

### DIFF
--- a/information-service/src/main/java/com/lms/informationservice/InformationServiceApplication.java
+++ b/information-service/src/main/java/com/lms/informationservice/InformationServiceApplication.java
@@ -15,8 +15,7 @@ public class InformationServiceApplication {
         System.setProperty("DB_TEAMS_URL", dotenv.get("DB_TEAMS_URL"));
         System.setProperty("DB_USERNAME", dotenv.get("DB_USERNAME"));
         System.setProperty("DB_PASSWORD", dotenv.get("DB_PASSWORD"));
-        String dbUrl = System.getProperty("DB_TEAMS_URL");
-        System.out.println(dbUrl);
+
 
         SpringApplication.run(InformationServiceApplication.class, args);
     }

--- a/information-service/src/main/java/com/lms/informationservice/InformationServiceApplication.java
+++ b/information-service/src/main/java/com/lms/informationservice/InformationServiceApplication.java
@@ -11,7 +11,7 @@ import io.github.cdimascio.dotenv.Dotenv;
 public class InformationServiceApplication {
 
     public static void main(String[] args) {
-        Dotenv dotenv = Dotenv.configure().directory("../").load();
+        Dotenv dotenv = Dotenv.load();
         System.setProperty("DB_TEAMS_URL", dotenv.get("DB_TEAMS_URL"));
         System.setProperty("DB_USERNAME", dotenv.get("DB_USERNAME"));
         System.setProperty("DB_PASSWORD", dotenv.get("DB_PASSWORD"));

--- a/notification-service/src/main/java/com/lms/notificationservice/NotificationServiceApplication.java
+++ b/notification-service/src/main/java/com/lms/notificationservice/NotificationServiceApplication.java
@@ -22,7 +22,7 @@ public class NotificationServiceApplication {
     private NotificationController notificationController;
 
     public static void main(String[] args) {
-        Dotenv dotenv = Dotenv.configure().directory("../").load();
+        Dotenv dotenv = Dotenv.load();
         System.setProperty("NOTIFICATION_SERVICE_APP_PASSWORD", dotenv.get("NOTIFICATION_SERVICE_APP_PASSWORD"));
         System.setProperty("DB_GAMES_URL", dotenv.get("DB_GAMES_URL"));
         System.setProperty("DB_USERNAME", dotenv.get("DB_USERNAME"));

--- a/user-service/src/main/java/com/lms/userservice/UserServiceApplication.java
+++ b/user-service/src/main/java/com/lms/userservice/UserServiceApplication.java
@@ -8,7 +8,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 public class UserServiceApplication {
 
     public static void main(String[] args) {
-        Dotenv dotenv = Dotenv.configure().directory("../").load();
+        Dotenv dotenv = Dotenv.load();
         System.setProperty("DB_USERNAME", dotenv.get("DB_USERNAME"));
         System.setProperty("DB_PASSWORD", dotenv.get("DB_PASSWORD"));
         System.setProperty("DB_USERS_URL", dotenv.get("DB_USERS_URL"));


### PR DESCRIPTION
In the recent notificationservice pr, dotenv was read at the root directory instead of per each service. I assumed this is how it should have been and retroactively changed each other dotenv file reading line. I realize now it makes more sense in microservice architecture to keep all services completely seperate, including .env files. 