### PR TITLE
Some auth stuff for game service added in

### DIFF
--- a/game-service/src/main/java/com/lms/gameservice/config/Config.java
+++ b/game-service/src/main/java/com/lms/gameservice/config/Config.java
@@ -1,0 +1,14 @@
+package com.lms.gameservice.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class Config {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/game-service/src/main/java/com/lms/gameservice/controller/GameController.java
+++ b/game-service/src/main/java/com/lms/gameservice/controller/GameController.java
@@ -1,6 +1,7 @@
 package com.lms.gameservice.controller;
 
 import com.lms.gameservice.model.Game;
+import com.lms.gameservice.service.AuthService;
 import com.lms.gameservice.service.GameService;
 import com.lms.gameservice.service.RoundService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,14 +17,20 @@ public class GameController {
     private final RoundService roundService;
 
     @Autowired
+    private AuthService authService;
+
+    @Autowired
     public GameController(GameService gameService, RoundService roundService) {
         this.gameService = gameService;
         this.roundService = roundService;
     }
 
     @PostMapping("/create")
-    public ResponseEntity<Game> createGame(@RequestBody Game game) {
-        return ResponseEntity.ok(gameService.createGame(game));
+    public ResponseEntity<?> createGame(@RequestBody Game game, @RequestHeader("Authorisation") String authorisationHeader) {
+        String uid = authService.validateToken(authorisationHeader);
+
+        Game createdGame = gameService.createGame(game, uid);
+        return ResponseEntity.ok(createdGame);
     }
 
     @PostMapping("/{gameId}/join")
@@ -46,6 +53,4 @@ public class GameController {
         //TODO get all games
         return null;
     }
-}
-
 }

--- a/game-service/src/main/java/com/lms/gameservice/service/AuthService.java
+++ b/game-service/src/main/java/com/lms/gameservice/service/AuthService.java
@@ -1,0 +1,32 @@
+package com.lms.gameservice.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.http.*;
+
+@Service
+public class AuthService {
+
+    @Autowired
+    private RestTemplate restTemplate;
+
+    public String validateToken(String token) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorisation", token);
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        ResponseEntity<String> response = restTemplate.exchange(
+                "http://localhost:8080/api/users/validate-token",
+                HttpMethod.POST,
+                entity,
+                String.class
+        );
+
+        if (response.getStatusCode().is2xxSuccessful()) {
+            return response.getBody();
+        } else {
+            throw new RuntimeException("Invalid or expired token");
+        }
+    }
+}

--- a/game-service/src/main/java/com/lms/gameservice/service/GameService.java
+++ b/game-service/src/main/java/com/lms/gameservice/service/GameService.java
@@ -7,8 +7,6 @@ import com.lms.gameservice.repository.PlayerRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
-
 @Service
 public class GameService {
     private final GameRepository gameRepository;
@@ -23,10 +21,10 @@ public class GameService {
 
     }
 
-    public Game createGame(Game game) {
+    public Game createGame(Game game, String uid) {
         return gameRepository.save(game);
     }
-
+    //TODO future user id will become string
     public Player joinGame(Long gameId, Long userId) {
         Game game = gameRepository.findById(gameId).orElseThrow(() -> new IllegalArgumentException("Game not found"));
         //TODO Need to get and pay entry fee here

--- a/user-service/src/main/java/com/lms/userservice/controller/UserController.java
+++ b/user-service/src/main/java/com/lms/userservice/controller/UserController.java
@@ -178,7 +178,7 @@ public class UserController {
      * @param authorisationHeader
      * @return
      */
-    @GetMapping("/secure-endpoint")
+    @GetMapping("/validate-jwt")
     public ResponseEntity<?> secureEndpoint(@RequestHeader("Authorisation") String authorisationHeader) {
         logger.info("Accessing secure endpoint.");
         try {


### PR DESCRIPTION
I have made a Auth service which essintial will call our authorisation endpoint which i renamed "validate-jwt" in the user service. So for each endpoint in the Game service we should have it somewhat as a way I setup create game

`


    @PostMapping("/create")
    public ResponseEntity<?> createGame(@RequestBody Game game, @RequestHeader("Authorisation") String authorisationHeader) {
        String uid = authService.validateToken(authorisationHeader);

        Game createdGame = gameService.createGame(game, uid);
        return ResponseEntity.ok(createdGame);
    }


`
(The @RequestHeader("Authorisation") String authorisationHeader would need to be included in each one, then based of if this JWT token is correct, it will get the uid (new user ID, explain at end)
Essentially each endpoint that needs to be acted as if a user is logged in will call the auth service which calls our validate-jwt token. An example of what endpoint would be
![image](https://github.com/user-attachments/assets/88504868-f244-4e61-95e7-dd52d9390a3c)
Which would be followed by putting Key as authorisation and value as Bearer JWT TOKEN which you will place in the Params part of postman


![image](https://github.com/user-attachments/assets/94ec6cb7-b3c4-42d3-8c8f-a8bd1f86b0ab)
(Bear in mind, at the moment currently when you login it returns this JWT TOKEN)

Hasn't been tested yet but logic wise seems sound to me. One thing is we currently auto increment the user id in database but think we will need to now Store the firebase UID created as the user id


