### PR TITLE
Fix for GET endpoint to get user by specific ID

### DIFF
--- a/user-service/src/main/java/com/lms/userservice/controller/UserController.java
+++ b/user-service/src/main/java/com/lms/userservice/controller/UserController.java
@@ -170,7 +170,7 @@ public class UserController {
      * @return the User entity or 404 Not Found if the user does not exist
      */
     @GetMapping("/{id}")
-    public ResponseEntity<User> getUserById(@PathVariable Long id) {
+    public ResponseEntity<User> getUserById(@PathVariable String id) {
         logger.info("Fetching user with ID: {}", id);
         User user = userService.getUserById(id);
         if (user != null) {

--- a/user-service/src/main/java/com/lms/userservice/repository/UserRepository.java
+++ b/user-service/src/main/java/com/lms/userservice/repository/UserRepository.java
@@ -20,7 +20,8 @@ import java.util.Optional;
  * @author Olan Healy
  */
 @Repository
-public interface UserRepository extends JpaRepository<User, Long> {
+public interface UserRepository extends JpaRepository<User, String> {
     Optional<User> findByEmail(String email);
     Optional<User> findByUsername(String username);
+    Optional<User> findById(String id);
 }

--- a/user-service/src/main/java/com/lms/userservice/service/UserService.java
+++ b/user-service/src/main/java/com/lms/userservice/service/UserService.java
@@ -92,7 +92,7 @@ public class UserService {
      * @return the user if found, or null if not found.
      */
 
-    public User getUserById(Long id) {
+    public User getUserById(String id) {
         return userRepository.findById(id).orElse(null);
     }
 

--- a/user-service/src/test/java/com/lms/userservice/controller/UserControllerTest.java
+++ b/user-service/src/test/java/com/lms/userservice/controller/UserControllerTest.java
@@ -90,9 +90,11 @@ class UserControllerTest {
 
     @Test
     void testGetUserByIdUserExists() {
-        when(userService.getUserById(1L)).thenReturn(user);
+        String userId = "test-uid-123";
+        when(userService.getUserById(userId)).thenReturn(user);
 
-        ResponseEntity<User> response = userController.getUserById(1L);
+
+        ResponseEntity<User> response = userController.getUserById(userId);
 
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertEquals(user, response.getBody());
@@ -100,9 +102,10 @@ class UserControllerTest {
 
     @Test
     void testGetUserByIdUserNotFound() {
-        when(userService.getUserById(1L)).thenReturn(null);
+        String userId = "non-existing-uid";
+        when(userService.getUserById(userId)).thenReturn(null);
 
-        ResponseEntity<User> response = userController.getUserById(1L);
+        ResponseEntity<User> response = userController.getUserById(userId);
 
         assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
     }


### PR DESCRIPTION
SInce we updated to store UID as user id, I have updated the GetUserById to take a String and made necessary updates with test cases and user service. Now This endpoint can take in user id string to get a user by their id: eg
![image](https://github.com/user-attachments/assets/2d35accf-70c2-406b-9b7f-38a7219b7b25)

