### PR TITLE
Endpoints working as admin

### DIFF
--- a/game-service/src/main/java/com/lms/gameservice/service/AuthService.java
+++ b/game-service/src/main/java/com/lms/gameservice/service/AuthService.java
@@ -8,6 +8,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 @Service
 public class AuthService {
 
@@ -32,6 +35,27 @@ public class AuthService {
             return response.getBody();
         } else {
             throw new RuntimeException("Invalid or expired token");
+        }
+    }
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    // Return isAdmin field from user-service
+    public boolean getUserAdminStatus(String token, String userId) {
+        String url = "http://user-service:8080/api/users/" + userId;  // Replace with your endpoint
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorisation", token);
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        ResponseEntity<String> response = restTemplate.exchange(url, HttpMethod.GET, entity, String.class);
+
+        try {
+            // Parse response to get only the 'isAdmin' field
+            JsonNode root = objectMapper.readTree(response.getBody());
+            return root.path("isAdmin").asBoolean(false);  // Default to false if isAdmin is not found
+        } catch (Exception e) {
+            throw new RuntimeException("Error parsing user admin status: " + e.getMessage(), e);
         }
     }
 }


### PR DESCRIPTION
There are three endpoints in GameController that are only used for testing methods that are set on a timer / Cron.
I've updated these to now only be usable by users who are set to admin.

so when admin is set to 0:
![admin0](https://github.com/user-attachments/assets/9378c653-c497-4dbf-b563-9c6d55b35432)

we get the following when using the endpoints:
![image](https://github.com/user-attachments/assets/946d3bf7-9239-4f0c-96fa-53d632259f4f)
![image](https://github.com/user-attachments/assets/9b18634e-4c74-4250-b260-88c5ffcfbbb1)
![image](https://github.com/user-attachments/assets/74d8a18c-8229-4a48-82d3-6e618be2bf67)

When we set the user toadmin,
![image](https://github.com/user-attachments/assets/f104a7cc-d08a-4c66-abe1-be5f548cf1fd)

the endpoints work as intended:
![image](https://github.com/user-attachments/assets/0019c86f-ded7-4db0-9748-42f60b3efee3)


